### PR TITLE
#19 -- Record information on multiple expectation failure an include in report

### DIFF
--- a/R/property.R
+++ b/R/property.R
@@ -92,12 +92,12 @@ forall <- function( generator
       # counterexample we can ( by shrinking ).
       counterexample <- find.smallest( tree, property, curry, shrink.limit, 0, discards, discard.limit )
 
-      # Rerun the smallest counterexample to grab the specific error
-      test_error     <- run.prop( property, counterexample$smallest, curry )$test_error
+      # Rerun the smallest counterexample to grab the specific errors
+      test_errors     <- run.prop( property, counterexample$smallest, curry )$test_errors
 
       # Make a nice error report for the user.
       report_        <- capture.output(print(
-                          report( test, counterexample$shrinks, test_error, counterexample$smallest )
+                          report( test, counterexample$shrinks, test_errors, counterexample$smallest )
                         ))
       # Exit the loop with failure, this will be picked up
       # by testthat and displayed nicely.

--- a/R/report.R
+++ b/R/report.R
@@ -24,11 +24,12 @@ print.report <- function ( x, ... ) {
     # Print a nice message for the user.
     # This could be moved into a fully fledged
     # report type.
-    cat ( paste("Falsifiable after", x$tests, "tests, and",  x$shrinks, "shrinks\n") )
+    cat ( paste("Falsifiable after", x$tests, "tests, and",  x$shrinks, "shrinks\n\n") )
 
     # Print the messages which come with the counterexample.
     for (message in x$messages) {
       print ( message )
+      cat ( "\n" )
     }
 
     # Show the counterexamples

--- a/R/report.R
+++ b/R/report.R
@@ -4,16 +4,16 @@
 #   the test on which the failure occurred
 # @param shrinks
 #   how many shrinks were performed
-# @param message
-#   the error message to print
+# @param messages
+#   a list of the error messages to print
 # @param counterexample
 #   the smallest counterexample to print
-report <- function ( tests, shrinks, message, counterexample ) {
+report <- function ( tests, shrinks, messages, counterexample ) {
   structure (
     list (
       tests = tests
     , shrinks = shrinks
-    , message = message
+    , messages = messages
     , counterexample = counterexample
     ), class = "report"
   )
@@ -26,8 +26,10 @@ print.report <- function ( x, ... ) {
     # report type.
     cat ( paste("Falsifiable after", x$tests, "tests, and",  x$shrinks, "shrinks\n") )
 
-    # Print the message which comes with the counterexample.
-    print ( x$message )
+    # Print the messages which come with the counterexample.
+    for (message in x$messages) {
+      print ( message )
+    }
 
     # Show the counterexamples
     cat ( "Counterexample:\n")

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -27,7 +27,7 @@
 # @return the error and a bool indicating success.
 run.prop <- function ( property, arguments, curry ) {
   arguments  <- if ( curry ) arguments else list ( arguments )
-  test_error <- NULL
+  test_errors <- list()
   handled    <- F
   discard    <- F
   ok         <- T
@@ -37,9 +37,8 @@ run.prop <- function ( property, arguments, curry ) {
     e_ok        <- expectation_ok(e)
     ok         <<- ok && e_ok
 
-    # Register first failure only.
-    if (isFALSE(e_ok) && is.null(test_error)) {
-      test_error <<- e
+    if (isFALSE(e_ok)) {
+      test_errors <<- c(test_errors, list(e))
     }
   }
 
@@ -47,15 +46,14 @@ run.prop <- function ( property, arguments, curry ) {
     handled    <<- TRUE
     register_expectation(e)
     e$handled   <- TRUE
-    test_error <<- e
   }
 
   handle_fatal <- function(e) {
     handled <<- TRUE
     # Quote: Hadley
     # > Error caught in handle_error() has precedence
-    if (!is.null(test_error)) {
-      if (isTRUE(test_error$handled)) {
+    if (length(test_errors) == 0) {
+      if (all(isTRUE(test_errors$handled))) {
         return()
       }
     }
@@ -98,7 +96,7 @@ run.prop <- function ( property, arguments, curry ) {
     )
   , error = handle_fatal
   )
-  list ( discard = discard, ok = ok, test_error = test_error)
+  list ( discard = discard, ok = ok, test_errors = test_errors)
 }
 
 # From testthat.

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -34,8 +34,13 @@ run.prop <- function ( property, arguments, curry ) {
 
   register_expectation <- function(e) {
     e           <- as.expectation(e)
-    test_error <<- e
-    ok         <<- ok && expectation_ok(e)
+    e_ok        <- expectation_ok(e)
+    ok         <<- ok && e_ok
+
+    # Register first failure only.
+    if (isFALSE(e_ok) && is.null(test_error)) {
+      test_error <<- e
+    }
   }
 
   handle_error <- function(e) {


### PR DESCRIPTION
This is a proposed fix for #19 

It records all failing expectations and prints those during reporting.

Here is a working example:

```r
devtools::install_github("gregmuellegger/r-hedgehog", ref = "19-fix-expect-failure-reporting")

library(testthat)
library(hedgehog)

test_that("Demo: shows all failing expectations now", {
    forall(
        gen.element(1:10),
        function (n) {
            expect_equal(n, n + 1)
            expect_equal(n, n + 2)
            
            expect_equal(n, n)
        }
    )
})
```

output:

```
── Failure: Demo: shows all failing expectations now ───────────────────────────
Falsifiable after 1 tests, and 1 shrinks

<expectation_failure/expectation/error/condition>
`n` not equal to n + 1.
1/1 mismatches
[1] 1 - 2 == -1
Backtrace:
     ▆
  1. └─hedgehog::forall(...)
  2.   └─hedgehog:::run.prop(property, counterexample$smallest, curry)
  3.     ├─base::tryCatch(...)
  4.     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
  5.     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
  6.     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
  7.     ├─base::withCallingHandlers(...)
  8.     ├─base::do.call(property, arguments)
  9.     └─`<fn>`(1L)
 10.       └─testthat::expect_equal(n, n + 1)

<expectation_failure/expectation/error/condition>
`n` not equal to n + 2.
1/1 mismatches
[1] 1 - 3 == -2
Backtrace:
     ▆
  1. └─hedgehog::forall(...)
  2.   └─hedgehog:::run.prop(property, counterexample$smallest, curry)
  3.     ├─base::tryCatch(...)
  4.     │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
  5.     │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
  6.     │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
  7.     ├─base::withCallingHandlers(...)
  8.     ├─base::do.call(property, arguments)
  9.     └─`<fn>`(1L)
 10.       └─testthat::expect_equal(n, n + 2)

Counterexample:
[1] 1
```