### PR TITLE
Fixes for upcoming testthat 3.3.0 release

### DIFF
--- a/R/testthat.R
+++ b/R/testthat.R
@@ -80,7 +80,7 @@ run.prop <- function ( property, arguments, curry ) {
     discard <<- TRUE
   }
 
-tryCatch(
+  tryCatch(
     withCallingHandlers({
           do.call( property, arguments )
           if (!handled)
@@ -123,7 +123,7 @@ as.expectation.expectation <- function(x, ..., srcref = NULL) {
 }
 as.expectation.logical <- function(x, message, ..., srcref = NULL, info = NULL) {
   type <- if (x) "success" else "failure"
-  testthat::expectation(type, paste(message, info, sep = "\n"), srcref = srcref)
+  testthat::new_expectation(type, paste(message, info, sep = "\n"), srcref = srcref)
 }
 as.expectation.error <- function(x, ..., srcref = NULL) {
   error <- x$message
@@ -133,10 +133,10 @@ as.expectation.error <- function(x, ..., srcref = NULL) {
 }
 as.expectation.warning <- function(x, ..., srcref = NULL) {
   msg <- x$message
-  testthat::expectation("warning", msg, srcref)
+  testthat::new_expectation("warning", msg, srcref = srcref)
 }
 as.expectation.skip <- function(x, ..., srcref = NULL) {
   error <- x$message
   msg <- gsub("Error.*?: ", "", as.character(error))
-  testthat::expectation("skip", msg, srcref)
+  testthat::new_expectation("skip", msg, srcref = srcref)
 }

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -60,7 +60,8 @@ run.prop <- function ( property, arguments, curry ) {
   handle_expectation <- function(e) {
     handled <<- TRUE
     register_expectation(e)
-    invokeRestart("continue_test")
+    tryInvokeRestart("muffle_expectation") # testthat >= 3.3.0
+    tryInvokeRestart("continue_test")      # testthat < 3.3.0
   }
 
   handle_warning <- function(e) {
@@ -79,7 +80,7 @@ run.prop <- function ( property, arguments, curry ) {
     discard <<- TRUE
   }
 
-  tryCatch(
+tryCatch(
     withCallingHandlers({
           do.call( property, arguments )
           if (!handled)
@@ -93,6 +94,7 @@ run.prop <- function ( property, arguments, curry ) {
     )
   , error = handle_fatal
   )
+  
   list ( discard = discard, ok = ok, test_error = test_error)
 }
 
@@ -127,7 +129,7 @@ as.expectation.error <- function(x, ..., srcref = NULL) {
   error <- x$message
   msg <- gsub("Error.*?: ", "", as.character(error))
   msg <- gsub("\n$", "", msg)
-  testthat::expectation("error", msg, srcref)
+  testthat::new_expectation("error", msg, srcref = srcref)
 }
 as.expectation.warning <- function(x, ..., srcref = NULL) {
   msg <- x$message


### PR DESCRIPTION
Not quite there yet, but I think this is the most important part: the signature for creating an expectation has changed, and the name of the continue restart has also changed. I'll hopefully finish it off this afternoon.

Fixes #21